### PR TITLE
README updated to be a bit clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,9 @@ import mapboxgl from 'mapbox-gl';
 import PlacesAutocomplete from 'places-autocomplete';
 import 'places-autocomplete/index.css';
 
-/* 
-   Enter your access token that associates your 
-   Mapbox GL JS map with a Mapbox account
-*/
+/* Enter your access token that associates your 
+   Mapbox GL JS map with a Mapbox account */
 mapboxgl.accessToken = 'pk.abcd1234...';
-
 
 const mapboxglMap = new mapboxgl.Map({ /* your map options */ 
     container: 'map',                               // container ID
@@ -34,7 +31,6 @@ const mapboxglMap = new mapboxgl.Map({ /* your map options */
 });
 
 // container - the HTML element in which the map needs to be placed
-
 
 const autocomplete = new PlacesAutocomplete({
   mapboxToken: mapboxgl.accessToken,

--- a/README.md
+++ b/README.md
@@ -19,8 +19,22 @@ import mapboxgl from 'mapbox-gl';
 import PlacesAutocomplete from 'places-autocomplete';
 import 'places-autocomplete/index.css';
 
+/* 
+   Enter your access token that associates your 
+   Mapbox GL JS map with a Mapbox account
+*/
 mapboxgl.accessToken = 'pk.abcd1234...';
-const mapboxglMap = new mapboxgl.Map({ /* your map options */ });
+
+
+const mapboxglMap = new mapboxgl.Map({ /* your map options */ 
+    container: 'map',                               // container ID
+    style: 'mapbox://styles/mapbox/streets-v12',    // style URL
+    center: [-74.5, 40],                            // starting position [longitude, latiude]
+    zoom: 9                                         // zoom level
+});
+
+// container - the HTML element in which the map needs to be placed
+
 
 const autocomplete = new PlacesAutocomplete({
   mapboxToken: mapboxgl.accessToken,
@@ -31,6 +45,8 @@ const autocomplete = new PlacesAutocomplete({
 const inputEl = document.getElementById('my-input');
 autocomplete.attachTo(inputEl);
 ```
+
+You can find a variety of styling options for the style parameter in the mapboxgl initialisation [here](https://docs.mapbox.com/api/maps/styles/#mapbox-styles)
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const inputEl = document.getElementById('my-input');
 autocomplete.attachTo(inputEl);
 ```
 
-You can find a variety of styling options for the style parameter in the mapboxgl initialisation [here](https://docs.mapbox.com/api/maps/styles/#mapbox-styles)
+You can find a variety of styling options for the style parameter in the mapboxgl initialisation [here](https://docs.mapbox.com/api/maps/styles/#mapbox-styles).
 
 ### Options
 


### PR DESCRIPTION
The mapboxgl component without any initialising map options was throwing an error thus mentioning few details to make things more clear and concise . I have added a sample map options initialisation and defined what each of those variables associate to.

const mapboxglMap = new mapboxgl.Map({ /* your map options */ 
    container: 'map',                               // container ID
    style: 'mapbox://styles/mapbox/streets-v12',    // style URL
    center: [-74.5, 40],                            // starting position [longitude, latiude]
    zoom: 9                                         // zoom level
});

Also added an external link to the documentation to browse the various styling options available.
In my opinion this would save one's time from looking up the documentation and make the README more self explanatory.